### PR TITLE
mark all fields with format text

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Catmandu-XLS
 
 {{$NEXT}}
+  - Catmandu::Exporter::XLSX: mark all fields with format '@' so that no fields are formatted unexpectedly (like numbers)
 
 0.10  2021-01-04 11:56:00 CET
   - use the TabularExporter role

--- a/lib/Catmandu/Exporter/XLSX.pm
+++ b/lib/Catmandu/Exporter/XLSX.pm
@@ -12,7 +12,7 @@ with 'Catmandu::TabularExporter';
 has xlsx      => (is => 'ro', lazy => 1, builder => '_build_xlsx');
 has worksheet => (is => 'ro', lazy => 1, builder => '_build_worksheet');
 has _n => (is => 'rw', default => sub {0});
-has num_format => (is => 'lazy', init_arg => undef);
+has _num_format => (is => 'lazy', init_arg => undef);
 
 sub BUILD {
     my $self    = shift;
@@ -30,7 +30,7 @@ sub _build_xlsx {
     $xlsx;
 }
 
-sub _build_num_format {
+sub _build__num_format {
     $_[0]->xlsx->add_format(num_format => '@');
 }
 
@@ -43,7 +43,7 @@ sub encoding {':raw'}
 sub add {
     my ($self, $data) = @_;
     my $fields = $self->fields || $self->fields([sort keys %$data]);
-    my $num_format = $self->num_format;
+    my $num_format = $self->_num_format;
 
     if ($self->header && $self->_n == 0) {
         for (my $i = 0; $i < @$fields; $i++) {

--- a/lib/Catmandu/Exporter/XLSX.pm
+++ b/lib/Catmandu/Exporter/XLSX.pm
@@ -12,6 +12,7 @@ with 'Catmandu::TabularExporter';
 has xlsx      => (is => 'ro', lazy => 1, builder => '_build_xlsx');
 has worksheet => (is => 'ro', lazy => 1, builder => '_build_worksheet');
 has _n => (is => 'rw', default => sub {0});
+has num_format => (is => 'lazy', init_arg => undef);
 
 sub BUILD {
     my $self    = shift;
@@ -29,6 +30,10 @@ sub _build_xlsx {
     $xlsx;
 }
 
+sub _build_num_format {
+    $_[0]->xlsx->add_format(num_format => '@');
+}
+
 sub _build_worksheet {
     $_[0]->xlsx->add_worksheet;
 }
@@ -38,6 +43,7 @@ sub encoding {':raw'}
 sub add {
     my ($self, $data) = @_;
     my $fields = $self->fields || $self->fields([sort keys %$data]);
+    my $num_format = $self->num_format;
 
     if ($self->header && $self->_n == 0) {
         for (my $i = 0; $i < @$fields; $i++) {
@@ -46,14 +52,14 @@ sub add {
             # keep for backward compatibility (header could be a hashref)
             $field = $self->header->{$field}
                 if ref $self->header && defined $self->header->{$field};
-            $self->worksheet->write_string($self->_n, $i, $field);
+            $self->worksheet->write_string($self->_n, $i, $field, $num_format);
         }
         $self->{_n}++;
     }
 
     for (my $i = 0; $i < @$fields; $i++) {
         $self->worksheet->write_string($self->_n, $i,
-            $data->{$fields->[$i]} // "");
+            $data->{$fields->[$i]} // "", $num_format);
     }
     $self->{_n}++;
 }


### PR DESCRIPTION
The current implementation sets no formatting when writing field values to a cell.
This means that the formatting is set to "General" which leaves the formatting
of those cells up to Excel. For values that look like numbers, that means that those
are treated as numbers. The same goes for values that look like dates.

I guess that all of the values should be treated as strings? That way values do not appear
differently when opened in Excel (like datestamps for example).

I have set the formatting of all cells to `@`